### PR TITLE
Remove Redundant Timestamp Cast

### DIFF
--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -27,7 +27,7 @@
 
     values (
         '{{ event_name }}',
-        {{dbt_utils.current_timestamp_in_utc()}},
+        convert_timezone('UTC', current_timestamp)::timestamp_ntz,
         {% if variable != None %}'{{ schema }}'{% else %}null::varchar(512){% endif %},
         {% if variable != None %}'{{ relation }}'{% else %}null::varchar(512){% endif %},
         '{{ invocation_id }}'


### PR DESCRIPTION
### Overview
As per Snowflake's suggestion, this PR replaces the `dbt_utils.current_timestamp_in_utc()` macro which generates the current timestamp in UTC with our own leaner version.

**NOTE:** This PR will require a follow-up git release (`0.1.8`) and version bump with `dataland` repo (See [#1390](https://github.com/goodeggs/dataland/pull/1390))